### PR TITLE
refactor: session cleanup to use setInterval

### DIFF
--- a/src/lib/server/session.ts
+++ b/src/lib/server/session.ts
@@ -89,7 +89,7 @@ export async function getSession(sid: Sid): Promise<SessionInfo | undefined> {
 	}
 }
 
-let nextClean = Date.now() + 1000 * 60 * 60; // 1 hour
+const cleanInterval = 1000 * 60 * 60; // 1 hour
 async function clean() {
 	await prisma.accountSessions.deleteMany({
 		where: { expires: { lt: Date.now() } },
@@ -100,14 +100,13 @@ async function clean() {
 			sessionStore.delete(sid);
 		}
 	}
-	nextClean = Date.now() + 1000 * 60 * 60; // 1 hour
 }
 
-if (Date.now() > nextClean) {
-	setTimeout(async () => {
-		await clean();
-	}, 5000);
-}
+void clean();
+
+setInterval(() => {
+	void clean();
+}, cleanInterval);
 
 export function requireLogin(
 	locals: App.Locals,


### PR DESCRIPTION
This pull request refactors the session cleanup logic in `src/lib/server/session.ts` to improve reliability and maintainability. The main change is replacing the previous time-based cleanup trigger with a recurring interval, ensuring expired sessions are consistently removed.

Session cleanup improvements:

* Replaced the manual calculation and conditional triggering of session cleanup with a `setInterval` that runs the `clean` function every hour, using a new `cleanInterval` constant for clarity.
* Removed the `nextClean` variable and related conditional logic, simplifying the cleanup scheduling. 